### PR TITLE
Use Imagick::setImageAlpha instead of Imagick::setImageOpacity if available (refs #4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "manticorp/image",
-    "description": "Image library for layer like blending of images in PHP",
+    "name": "cjrasmussen/blendable-image",
+    "description": "Temporary fork of manticorp/image",
     "require": {
         "php": ">=5.3.0"
     },

--- a/src/Image/Blender.php
+++ b/src/Image/Blender.php
@@ -32,7 +32,11 @@ class Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        $overlayImg->setImageOpacity($opacity);
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
 
         $method = explode("\\",get_class($this));
         $method = strtoupper(array_pop($method));
@@ -54,9 +58,13 @@ class Blender
             $baseImg    = $this->base->getImage();
             $overlayImg = $this->top->getImage();
 
-            $overlayImg->setImageOpacity($opacity);
+			if (method_exists($overlayImg, 'setImageAlpha')) {
+				$overlayImg->setImageAlpha($opacity);
+			} else {
+				$overlayImg->setImageOpacity($opacity);
+			}
 
-            if(!isset($options['botx'])) {
+			if(!isset($options['botx'])) {
                 $options['botx'] = 0;
             }
             if(!isset($options['boty'])) {

--- a/src/Image/Blender/Divide.php
+++ b/src/Image/Blender/Divide.php
@@ -65,7 +65,13 @@ class Divide extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
         // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_K, $options['offsetx'], $options['offsety']);
 

--- a/src/Image/Blender/HardMix.php
+++ b/src/Image/Blender/HardMix.php
@@ -67,9 +67,15 @@ class HardMix extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_K, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_K, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/LighterColor.php
+++ b/src/Image/Blender/LighterColor.php
@@ -62,9 +62,15 @@ class LighterColor extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/LinearBurn.php
+++ b/src/Image/Blender/LinearBurn.php
@@ -65,9 +65,15 @@ class LinearBurn extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/LinearDodge.php
+++ b/src/Image/Blender/LinearDodge.php
@@ -63,9 +63,15 @@ class LinearDodge extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/LinearLight.php
+++ b/src/Image/Blender/LinearLight.php
@@ -66,9 +66,15 @@ class LinearLight extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_T, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/PinLight.php
+++ b/src/Image/Blender/PinLight.php
@@ -66,9 +66,15 @@ class PinLight extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_E, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_E, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }

--- a/src/Image/Blender/VividLight.php
+++ b/src/Image/Blender/VividLight.php
@@ -66,9 +66,15 @@ class VividLight extends \Manticorp\Image\Blender
         $baseImg    = $this->base->getImage();
         $overlayImg = $this->top->getImage();
 
-        // $overlayImg->setImageOpacity($opacity);
+		/*
+        if (method_exists($overlayImg, 'setImageAlpha')) {
+			$overlayImg->setImageAlpha($opacity);
+		} else {
+			$overlayImg->setImageOpacity($opacity);
+		}
+		*/
 
-        // $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_E, $options['offsetx'], $options['offsety']);
+		// $baseImg->compositeImage($overlayImg, \Imagick::COMPOSITE_E, $options['offsetx'], $options['offsety']);
 
         return $baseImg;
     }


### PR DESCRIPTION
setImageOpacity was deprecated in ImageMagick 7.  Check for the existence of setImageAlpha and use it if available, only falling back to setImageOpacity if it's not.